### PR TITLE
Fix settings not persisted (#37)

### DIFF
--- a/src/Stein.Services/Configuration/ConfigurationService.cs
+++ b/src/Stein.Services/Configuration/ConfigurationService.cs
@@ -72,9 +72,13 @@ namespace Stein.Services.Configuration
         {
             var fileNameWithHighestVersion = fileNames.Select(fileName =>
                 {
-                    var splitFileName = fileName.Split('.');
+                    // full file name may contains logins with dots... only file name check should be made
+                    string fileNameFromPath = Path.GetFileName(fileName);
+
+                    var splitFileName = fileNameFromPath.Split('.');
                     if (splitFileName.Length != 3)
                         return new Tuple<string, long?>(fileName, null);
+                    
                     var fileVersionString = String.Join(String.Empty, splitFileName[1].Skip(1));
                     return long.TryParse(fileVersionString, out var fileVersion)
                         ? new Tuple<string, long?>(fileName, fileVersion)


### PR DESCRIPTION
## Summary
if user name or directory name contains dot, then setting file is not correctly interpreted (Split.Length > 3). Fixes #37 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)